### PR TITLE
chore(travis): set permissions on built file

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "babel src -d bin -x .lsc",
     "watch": "npm run build -- -w",
-    "pretest": "npm run build",
+    "pretest": "npm run build && node ./permfix.js",
     "test": "ava",
     "prepublish": "npm run build"
   },

--- a/permfix.js
+++ b/permfix.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+'use strict'
+
+if (process.platform === 'win32') {
+  process.exit(0)
+}
+
+const execa = require('execa')
+
+try { execa.shellSync('chmod +x bin/index.js') }
+catch (e) { console.error(e.stack) }
+finally { process.exit(0) }


### PR DESCRIPTION
Fix travis failing due to the built cli file not having the executable flag.